### PR TITLE
made UMD importable in Node

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,8 @@
 import CE from 'custom-event'
 
-window.requestAnimationFrame = window.requestAnimationFrame || window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame
+if (typeof window !== 'undefined') {
+  window.requestAnimationFrame = window.requestAnimationFrame || window.webkitRequestAnimationFrame || window.mozRequestAnimationFrame
+}
 
 /**
  *

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,7 +83,8 @@ if (isDev) {
     chunkFilename: assetsPath('[id].js'),
     library: 'rangesliderJs',
     libraryExport: 'default',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'Function("return this")()'
   }
   conf.plugins.push(
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Set the Webpack output globalObject to something more generic, so that Next.js no longer depends on "window"